### PR TITLE
Fix CORS headers so that they actually work.

### DIFF
--- a/src/protocol_http.c
+++ b/src/protocol_http.c
@@ -159,8 +159,19 @@ static void http_begin_headers
   /* Cross-site scripting - allows accessing the server with browser from
    * different origin, but can be a security hole. */
   if (config_to_bool("enable-xss")) {
-    client_send(http->client, "Access-Control-Allow-Origin: *\r\n");
-    client_send(http->client, "Access-Control-Allow-Credentials: *\r\n");
+    const char *origin_start = strcasestr(http->request, "\r\nOrigin: ");
+    if (origin_start) {
+      const char *origin_end = strchrnull(origin_start + 1, '\r');
+      char *origin = strextract(origin_start + 2, origin_end);
+
+      client_send(http->client, "Access-Control-Allow-");
+      client_send(http->client, origin);
+      client_send(http->client, "\r\n");
+
+      free(origin);
+
+      client_send(http->client, "Access-Control-Allow-Credentials: true\r\n");
+    }
   }
 }
 


### PR DESCRIPTION
Access-Control-Allow-Credentials should be "true" instead of "_", and a non-_ origin must be specified via Access-Control-Allow-Origin in order for credentials to work.
